### PR TITLE
Fixed domain not displaying in Messaging Interactions API documentation

### DIFF
--- a/pages/documents/data/messaging-interactions/methods/conversations.md
+++ b/pages/documents/data/messaging-interactions/methods/conversations.md
@@ -15,7 +15,7 @@ This method retrieves a list of conversations with all their metadata and relate
 
 Method | URL
 ------ | ---------------------------------------------------------------------------------------------------
-POST   | https://<domain>/messaging_history/api/account/{accountID}/conversations/search?offset=0&limit=50
+POST   | https://{domain}/messaging_history/api/account/{accountID}/conversations/search?offset=0&limit=50
 
 **URL Parameters**
 

--- a/pages/documents/data/messaging-interactions/methods/get-conversation-by-conversation-id.md
+++ b/pages/documents/data/messaging-interactions/methods/get-conversation-by-conversation-id.md
@@ -16,7 +16,7 @@ This method retrieves a conversation according to the given conversation ID.
 
 Method     | URL
 --------   | ---
-POST       | https://<domain>/messaging_history/api/account/{accountID}/conversations/conversation/search
+POST       | https://{domain}/messaging_history/api/account/{accountID}/conversations/conversation/search
 
 **BODY/POST Parameters**
 

--- a/pages/documents/data/messaging-interactions/methods/get-conversations-by-consumer-id.md
+++ b/pages/documents/data/messaging-interactions/methods/get-conversations-by-consumer-id.md
@@ -16,7 +16,7 @@ This method retrieves a list of conversations that the consumer participated in.
 
 Method     | URL
 --------   | ---
-POST       | https://<domain>/messaging_history/api/account/{accountID}/conversations/consumer/search
+POST       | https://{domain}/messaging_history/api/account/{accountID}/conversations/consumer/search
 
 **BODY/POST Parameters**
 


### PR DESCRIPTION
Updated the markdown for <domain> in the messaging interactions api documentation to be {domain}, that way it will display.