### PR TITLE
Update add-lines.md

### DIFF
--- a/pages/documents/agent-interactions/chat-agent/Methods/add-lines.md
+++ b/pages/documents/agent-interactions/chat-agent/Methods/add-lines.md
@@ -69,14 +69,14 @@ Request body examples:
 
 It is possible to add different types of lines to the chat. When no text type is defined, it is assumed that a plain type was submitted.
 
-**Best Practice**: our embedded window relies on the LE Agent UI to display the above sent text in an HTML format with a "<div>" wrapper. Therefore, to make sure that the LiveEngage UI displays your text correctly, it is important to use the HTML format as seen in the example above. The provided html cannot include the following: Iframes, Scripts, DOM actions, Links with "target="_blank".
+**Best Practice**: our embedded window relies on the LE Agent UI to display the above sent text in an HTML format with a "<div>" wrapper. Therefore, to make sure that the LiveEngage UI displays your text correctly, it is important to use the HTML format as seen in the example above. The provided html cannot include the following: Iframes, Scripts, DOM actions, Links with a target other than "_blank".
 
 Changing the text type is handled as follows:
 
 | Name  | Description  | Notes |
 |-------|-------------|----------|
 | plain | The default type when non used, the text will be displayed as provided |    |
-| html | For passing HTML content from the agent to the chat session.  | The provided html cannot include the following: Iframes, Scripts, DOM actions, Links with target="_blank". |
+| html | For passing HTML content from the agent to the chat session.  | The provided html cannot include the following: Iframes, Scripts, DOM actions, Links with targets (*all targets will be rewriten to "_blank"*). |
 | rich-content | For passing Structured Content templates | [Refer to the Structured Content Templates document](structured-content-templates.html)  |
 
 ### Response


### PR DESCRIPTION
Contrary to the documentation, links can only contain _target="_blank"_. When no target is defined, __blank_ will be added by the platform. Any other target will be removed and replaced.