### PR TITLE
Fix Start chat body parameters description

### DIFF
--- a/pages/documents/consumer experience/server-chat/Methods/start-chat.md
+++ b/pages/documents/consumer experience/server-chat/Methods/start-chat.md
@@ -40,7 +40,7 @@ _For Visitor Authentication flow please collect necessary parameters from the [f
 
 **Body Parameters**
 
-Note that we expect you to send the parameters under the `"request"` key - see the Requset Body Example
+Note that we expect you to send the parameters under the `"request"` key - see the Request Body Example
 
 | Name	| Description | Type/Value | Notes |
 | :--- | :--- | :--- | :--- |

--- a/pages/documents/consumer experience/server-chat/Methods/start-chat.md
+++ b/pages/documents/consumer experience/server-chat/Methods/start-chat.md
@@ -40,6 +40,8 @@ _For Visitor Authentication flow please collect necessary parameters from the [f
 
 **Body Parameters**
 
+Note that we expect you to send the parameters under the `"request"` key - see the Requset Body Example
+
 | Name	| Description | Type/Value | Notes |
 | :--- | :--- | :--- | :--- |
 | skill | Requests a chat with a specific skill. | alphanumeric | |


### PR DESCRIPTION
Specifically mention "request" key in the Body Parameters description