### PR TITLE
Removed extra character in URL

### DIFF
--- a/pages/documents/agent-interactions/login/methods/applicationlogin.md
+++ b/pages/documents/agent-interactions/login/methods/applicationlogin.md
@@ -15,7 +15,7 @@ indicator: both
 
 | Method | URL |
 | :--- | :--- |
-| POST |  https://{domain}/api/account/{accountId}]/login?v=1.3 |
+| POST |  https://{domain}/api/account/{accountId}/login?v=1.3 |
 
 **Query Parameters**
 


### PR DESCRIPTION
On the Application Login method of the Login Service API, the URL has an extra ']'.

This is for #212 