### PR TITLE
Bot agent state set to away by system

### DIFF
--- a/pages/documents/AgentExperienceAndBots/ChatAgentAPI/Methods/accept-chat.md
+++ b/pages/documents/AgentExperienceAndBots/ChatAgentAPI/Methods/accept-chat.md
@@ -16,7 +16,8 @@ indicator: chat
 
 This method accepts the next chat request.
 
-*Note: You should verify the results to see if there are any chat requests before accessing the resource.*
+**Note 1**: *You should verify the results to see if there are any chat requests before accessing the resource.*
+**Note 2**: *If an assigned chat is not accepted within 20 seconds, the system will assume the agent being idle and set the agent status to "away".*
 
 ### Request
 


### PR DESCRIPTION
*Reference case#00787574 - Chat Agent API bot going to away*
If an assigned chat is not accepted within 20 seconds, the system decides the agent must be idle and changes the agent state to 'away'.
In a scenario where a chat-bot is using the Chat Agent API, it should periodically check for it availability state and, if not intentionally away, set the status back to 'online'.

Should this also be added to the general [Retry and KeepAlive Best Practices](/retry-and-keepalive-best-practices-overview.html) and/or to a new page "Best Practices And Troubleshooting" within the Chat Agent API tree?