### PR TITLE
:pencil: Corrected misleading return types

### DIFF
--- a/pages/documents/DeveloperTools/FaaS/Developing/toolbelt.md
+++ b/pages/documents/DeveloperTools/FaaS/Developing/toolbelt.md
@@ -78,7 +78,7 @@ Searches the secret that belongs to the provided key. Will raise an error if the
 
 | Returns | Description |
 | :------- | :----- |
-| secretEntry | Object with properties `key` & `value` |
+| secretEntry | Promise which resolves to an Object with properties `key` & `value` |
 
 **SecretClient.updateSecret**
 
@@ -90,7 +90,7 @@ Updates the secret with the provided update entry.
 
 | Returns | Description |
 | :------- | :----- |
-| secretEntry | Created entry |
+| secretEntry | Promise which resolves to the created Secret with properties `key` & `value` |
 
 **Sample Usage**
 


### PR DESCRIPTION
The secret client returns Promises rather than already resolved Objects. This can be seen in the example code but is not properly reflected in the tables.