### PR TITLE
add formWrapper bottom margin, reduce input font-size and padding

### DIFF
--- a/css/register.css
+++ b/css/register.css
@@ -77,6 +77,7 @@ body {
   display: flex;
   justify-content: center;
   margin-top: 70px;
+  margin-bottom: 70px;
 }
 
 #registerForm {
@@ -90,18 +91,18 @@ body {
 #registerForm input {
   border: solid 1px #d6d6d6;
   background-color: #ffffff;
-  height: 30px;
-  margin-bottom: 20px;
-  padding: 10px 14px;
-  font-size: 18px;
+  height: 22px;
+  margin-bottom: 16px;
+  padding: 7px 10px;
+  font-size: 14px;
 }
 
 #region {
   border: solid 1px #d6d6d6;
   background-color: #ffffff;
-  height: 50px;
-  margin-bottom: 20px;
-  font-size: 18px;
+  height: 40px;
+  margin-bottom: 16px;
+  font-size: 14px;
   font-family: "Open Sans";
   font-weight: normal;
   font-style: italic;
@@ -131,14 +132,14 @@ select {
 
 input::-webkit-input-placeholder { /* Chrome/Opera/Safari */
   font-family: "Open Sans";
-  font-size: 18px;
+  font-size: 14px;
   font-weight: normal;
   font-style: italic;
   color: #666666;
 }
 input::-moz-placeholder { /* Firefox 19+ */
   font-family: "Open Sans";
-  font-size: 18px;
+  font-size: 14px;
   font-weight: normal;
   font-style: italic;
   color: #666666;
@@ -146,7 +147,7 @@ input::-moz-placeholder { /* Firefox 19+ */
 
 input:-ms-input-placeholder { /* IE 10+ */
   font-family: "Open Sans";
-  font-size: 18px;
+  font-size: 14px;
   font-weight: normal;
   font-style: italic;
   color: #666666;
@@ -154,7 +155,7 @@ input:-ms-input-placeholder { /* IE 10+ */
 
 input:-moz-placeholder { /* Firefox 18- */
   font-family: "Open Sans";
-  font-size: 18px;
+  font-size: 14px;
   font-weight: normal;
   font-style: italic;
   color: #666666;


### PR DESCRIPTION
Styling changes requested by Greg Fyke and James Poulin -- this branch can be pulled down and built locally with changes viewable at `/register.html`. 

I notice that select options don't completely align with the select element in chrome: this is a pre-existing issue that should be addressed separately, see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#Styling_with_CSS for details on potential mitigations/alternatives. 