### PR TITLE
Update campaigns-android.md

### DIFF
--- a/pages/documents/MessagingChannels/MobileAppMessagingSDKforAndroid/campaigns-android.md
+++ b/pages/documents/MessagingChannels/MobileAppMessagingSDKforAndroid/campaigns-android.md
@@ -133,6 +133,24 @@ identityList.add(monitoringIdentity);
 
 // Creating entryPoints object
 JSONArray entryPoints = new JSONArray();
+//
+// The next 3 lines are confusing developers. They give the impression that the entryPoints data will be available
+// in LiveEngage to match Engagements based on either URL or Section, and using language. This is not the case currently.
+// As currently implemented, the contents of each of the 3 lines below will appear in LiveEngage as section names exactly as
+// they are typed below - for example section 'http://www.liveperson-test.com', section 'sec://food' and section 'lang://De'
+//
+// So, either the lines below should be changed to highlight that entryPoints simply match to sections within LiveEngage
+// and the examples should be changed to something more meaningful
+//
+// OR - better yet
+//
+// The parsing within LiveEngage of entryPoints should be fixed to match what this example suggests was the original intention
+// with the
+// http line getting presented in LiveEngage as the current URL
+// sec line(s) getting presented in LiveEngage as the current section(s) 
+// lang line getting presented in LiveEngage as the current/desired language of the visitor
+//
+// Whichever is the outcome - some clarification of how the entryPoints are used is needed. 
 entryPoints.put("http://www.liveperson-test.com");
 entryPoints.put("sec://Food");
 entryPoints.put("lang://De");


### PR DESCRIPTION
It appears that somewhere along the way in the In-App SDK development cycle an idea to present URL, section, and language from the App to LiveEngage got lost or dropped. The sample code provided on the developers page gives the reader the impression that they can send this information to LiveEngage - but in fact LiveEngage cannot interpret it as it stands currently. I am not sure if the issue lies with the design or the implementation. 

Whichever way the platform is supposed to work, the sample code should match to the expectation with appropriate comments to inform the developer what they can pass to LiveEngage and how it will be used.