### PR TITLE
Fix/remove plus

### DIFF
--- a/_layouts/register.html
+++ b/_layouts/register.html
@@ -31,6 +31,7 @@
         <div id="byClicking"><input type="checkbox"><span> By clicking "Start Free Trial", I agree to the <a href="https://www.liveperson.com/policies/apitou">API Terms of Use</a> and <a href="https://www.liveperson.com/policies/privacy">Privacy Policy</a></span></div>
         <div id="registerContainer"><div id="registerButton"><span>Start Free Trial</span></div><img id="loader" src="img/oval.svg"></div>
         <span class="conditionButton" id="invalidEmail">Please enter a valid email address!</span>
+        <span class="conditionButton" id="invalidEmailWithPlus">Please enter an email address without a "+" character!</span>
         <span class="conditionButton" id="passwordErrorMatch">Your password and confirmation password don't match!</span>
         <span class="conditionButton" id="passwordTooShort">Please enter a password at least 8 characters long</span>
         <span class="conditionButton" id="passwordErrorStrength">Your password does meet the password requirements</span>

--- a/js/register.js
+++ b/js/register.js
@@ -78,7 +78,7 @@ function validateInfo (){
     $('#agreeButton').hide();
   }
   //check if email is valid
-  var emailRegexPtn = /^([a-zA-Z0-9_.+-])+\@(([a-zA-Z0-9-])+\.)+([a-zA-Z0-9]{2,4})+$/;
+  var emailRegexPtn = /^([a-zA-Z0-9_.-])+\@(([a-zA-Z0-9-])+\.)+([a-zA-Z0-9]{2,4})+$/;
   var isValidEmail = emailRegexPtn.test(emailAddress);
   if (!isValidEmail) {
       $('#invalidEmail').show();

--- a/js/register.js
+++ b/js/register.js
@@ -80,11 +80,20 @@ function validateInfo (){
   //check if email is valid
   var emailRegexPtn = /^([a-zA-Z0-9_.-])+\@(([a-zA-Z0-9-])+\.)+([a-zA-Z0-9]{2,4})+$/;
   var isValidEmail = emailRegexPtn.test(emailAddress);
+  var containsPlus = emailAddress.includes('+');
+
   if (!isValidEmail) {
       $('#invalidEmail').show();
+      if (containsPlus) {
+        $('#invalidEmailWithPlus').show();
+      }
   } else {
         $('#invalidEmail').hide();
+        // hide has no effect if already hidden so not necessary to track if it was previously visible or not
+        $('#invalidEmailWithPlus').hide();
   }
+
+
   //check password length
   if(password.length < 8) {
     $('#passwordTooShort').show();


### PR DESCRIPTION
Background:
* Registering an email with a plus sign "+" was generating a 400 error
* Denver/appserver doesn't follow the IMAP email address spec and doesn’t support it. 

This commit does two things:
* remove plus from the valid email regex
* show a custom message for "+" sign to let customers know that we don't follow the IMAP spec
