### PR TITLE
Add deprecation notice

### DIFF
--- a/pages/documents/MessagingChannels/MobileAppMessagingSDKforAndroid/VoiceandVideoforAndroidSDK/Changelog.md
+++ b/pages/documents/MessagingChannels/MobileAppMessagingSDKforAndroid/VoiceandVideoforAndroidSDK/Changelog.md
@@ -11,6 +11,12 @@ permalink: mobile-app-messaging-sdk-for-android-voice-and-video-for-android-sdk-
 indicator: messaging
 ---
 
+<div class="important">
+<h2>Deprecation Notice</h2>
+
+the CoApp product is deprecated and will be discontinued from February 28th, 2020 on.
+</div>
+
 <div class="subscribe">Working with this SDK or planning to in the future? Make sure to <a href="https://visualping.io/?url=developers.liveperson.com/consumer-experience-voice-video-android-changelog.html&mode=web&css=post-content" target="_blank">click here to subscribe to any further changes!</a> When the Release Notes are updated, you'll get a notification straight to your email of choice!</div>
 
 ### 0.1.0 (Beta)

--- a/pages/documents/MessagingChannels/MobileAppMessagingSDKforAndroid/VoiceandVideoforAndroidSDK/Customizing.md
+++ b/pages/documents/MessagingChannels/MobileAppMessagingSDKforAndroid/VoiceandVideoforAndroidSDK/Customizing.md
@@ -14,6 +14,12 @@ permalink: mobile-app-messaging-sdk-for-android-voice-and-video-for-android-sdk-
 indicator: messaging
 ---
 
+<div class="important">
+<h2>Deprecation Notice</h2>
+
+the CoApp product is deprecated and will be discontinued from February 28th, 2020 on.
+</div>
+
 ### Appearance and Behavior
 
 **Note**: Full white-labeling is currently not supported. If you are missing an important customization feature, please don't hesitate to contact your LivePerson account manager for help.

--- a/pages/documents/MessagingChannels/MobileAppMessagingSDKforAndroid/VoiceandVideoforAndroidSDK/FAQ.md
+++ b/pages/documents/MessagingChannels/MobileAppMessagingSDKforAndroid/VoiceandVideoforAndroidSDK/FAQ.md
@@ -11,6 +11,12 @@ permalink: mobile-app-messaging-sdk-for-android-voice-and-video-for-android-sdk-
 indicator: messaging
 ---
 
+<div class="important">
+<h2>Deprecation Notice</h2>
+
+the CoApp product is deprecated and will be discontinued from February 28th, 2020 on.
+</div>
+
 ### How much diskspace does the SDK need?
 
 * Universal build: **+40MB**

--- a/pages/documents/MessagingChannels/MobileAppMessagingSDKforAndroid/VoiceandVideoforAndroidSDK/GettingStarted.md
+++ b/pages/documents/MessagingChannels/MobileAppMessagingSDKforAndroid/VoiceandVideoforAndroidSDK/GettingStarted.md
@@ -16,6 +16,12 @@ permalink: mobile-app-messaging-sdk-for-android-voice-and-video-for-android-sdk-
 indicator: messaging
 ---
 
+<div class="important">
+<h2>Deprecation Notice</h2>
+
+the CoApp product is deprecated and will be discontinued from February 28th, 2020 on.
+</div>
+
 ### Prerequisites
 
 LivePerson Voice & Video is an SDK (_Software Development Kit_) for the **Google Android** platform. In order to integrate with us, you need to have an app of your own to which you have full source code access. Basic programming knowledge is required.

--- a/pages/documents/MessagingChannels/MobileAppMessagingSDKforAndroid/VoiceandVideoforAndroidSDK/Introduction.md
+++ b/pages/documents/MessagingChannels/MobileAppMessagingSDKforAndroid/VoiceandVideoforAndroidSDK/Introduction.md
@@ -12,6 +12,12 @@ root-link: true
 indicator: messaging
 ---
 
+<div class="important">
+<h2>Deprecation Notice</h2>
+
+the CoApp product is deprecated and will be discontinued from February 28th, 2020 on.
+</div>
+
 LivePerson's **Voice & Video SDK** allows you to communicate with your customers in realtime through your brand's app. The SDK enriches your app with realtime voice & video calling capabilities, built atop of our highly scalable **Messaging SDK** solution.
 
 ![screenshot_coapp](img/screenshot_coapp.png)

--- a/pages/documents/MessagingChannels/MobileAppMessagingSDKforAndroid/VoiceandVideoforAndroidSDK/Sample-Apps.md
+++ b/pages/documents/MessagingChannels/MobileAppMessagingSDKforAndroid/VoiceandVideoforAndroidSDK/Sample-Apps.md
@@ -11,4 +11,10 @@ permalink: mobile-app-messaging-sdk-for-android-voice-and-video-for-android-sdk-
 indicator: messaging
 ---
 
+<div class="important">
+<h2>Deprecation Notice</h2>
+
+the CoApp product is deprecated and will be discontinued from February 28th, 2020 on.
+</div>
+
 Bundled with our SDK are two sample applications - `GreatBank` and `CoApp-Sample`. They showcase a minimal setup of LivePerson's __LivePerson Live Voice & Video__ integrated with the __Messaging SDK__.

--- a/pages/documents/MessagingChannels/MobileAppMessagingSDKforAndroid/VoiceandVideoforAndroidSDK/liveengageConfiguration.md
+++ b/pages/documents/MessagingChannels/MobileAppMessagingSDKforAndroid/VoiceandVideoforAndroidSDK/liveengageConfiguration.md
@@ -16,6 +16,12 @@ permalink: mobile-app-messaging-sdk-for-android-voice-and-video-for-android-sdk-
 indicator: messaging
 ---
 
+<div class="important">
+<h2>Deprecation Notice</h2>
+
+the CoApp product is deprecated and will be discontinued from February 28th, 2020 on.
+</div>
+
 ### Agent Workspace Requirements
 
 Your agents will be using LiveEngage from a supported web browser to make calls to your consumers. This section explains how to setup your LiveEngage account for voice & video support.

--- a/pages/documents/MessagingChannels/MobileAppMessagingSDKforiOS/VoiceandVideoforiOSSDK/Changelog.md
+++ b/pages/documents/MessagingChannels/MobileAppMessagingSDKforiOS/VoiceandVideoforiOSSDK/Changelog.md
@@ -10,6 +10,12 @@ subfoldername: Voice and Video for iOS SDK (BETA)
 permalink: mobile-app-messaging-sdk-for-ios-voice-and-video-for-ios-sdk-beta-changelog.html
 indicator: messaging
 ---
+<div class="important">
+<h2>Deprecation Notice</h2>
+
+the CoApp product is deprecated and will be discontinued from February 28th, 2020 on.
+</div>
+
 <div class="subscribe">Working with this SDK or planning to in the future? Make sure to <a href="https://visualping.io/?url=developers.liveperson.com/consumer-experience-voice-video-ios-changelog.html&mode=web&css=post-content" target="_blank">click here to subscribe to any further changes!</a> When the Release Notes are updated, you'll get a notification straight to your email of choice!</div>
 
 

--- a/pages/documents/MessagingChannels/MobileAppMessagingSDKforiOS/VoiceandVideoforiOSSDK/Customizing.md
+++ b/pages/documents/MessagingChannels/MobileAppMessagingSDKforiOS/VoiceandVideoforiOSSDK/Customizing.md
@@ -14,6 +14,12 @@ permalink: mobile-app-messaging-sdk-for-ios-voice-and-video-for-ios-sdk-beta-cus
 indicator: messaging
 ---
 
+<div class="important">
+<h2>Deprecation Notice</h2>
+
+the CoApp product is deprecated and will be discontinued from February 28th, 2020 on.
+</div>
+
 ### Appearance and Behavior
 
 **Note**: Full white-labeling is currently not supported. If you are missing an important customization feature, don't hesitate to contact you LivePerson account manager for help.

--- a/pages/documents/MessagingChannels/MobileAppMessagingSDKforiOS/VoiceandVideoforiOSSDK/GettingStarted.md
+++ b/pages/documents/MessagingChannels/MobileAppMessagingSDKforiOS/VoiceandVideoforiOSSDK/GettingStarted.md
@@ -18,6 +18,12 @@ permalink: mobile-app-messaging-sdk-for-ios-voice-and-video-for-ios-sdk-beta-get
 indicator: messaging
 ---
 
+<div class="important">
+<h2>Deprecation Notice</h2>
+
+the CoApp product is deprecated and will be discontinued from February 28th, 2020 on.
+</div>
+
 ### Prerequisites
 
 LivePerson Voice & Video is a SDK (_Software Development Kit_) for the **Apple iOS** platform. In order to integrate with us, you need to have an app of your own to which you have full source code access. Basic programming knowledge is required.

--- a/pages/documents/MessagingChannels/MobileAppMessagingSDKforiOS/VoiceandVideoforiOSSDK/Introduction.md
+++ b/pages/documents/MessagingChannels/MobileAppMessagingSDKforiOS/VoiceandVideoforiOSSDK/Introduction.md
@@ -5,19 +5,15 @@ redirect_from:
   - voice-and-video-for-ios-sdk-beta-overview.html
 sitesection: Documents
 categoryname: "Messaging Channels"
-documentname: Mobile App Messaging SDK for iOS
+documentname: Deprecated - Mobile App Messaging SDK for iOS
 subfoldername: Voice and Video for iOS SDK (BETA)
 permalink: mobile-app-messaging-sdk-for-ios-voice-and-video-for-ios-sdk-beta-overview.html
 root-link: true
 indicator: messaging
 ---
 
-LivePerson's **Voice & Video SDK** allows you to communicate with your customers in realtime through your brand's app. The SDK enriches your app with realtime voice & video calling capabilities, built atop of our highly scalable **Messaging SDK** solution.
+<div class="important">
+<h2>Deprecation Notice</h2>
 
-![Introduction](img/iphone_001.png){:style="max-height:420px;"}
-
-Your agents engage from a web browser using our LiveEngage platform, while your consumers will be using your brand's own app, obtained fom the AppStore.
-
-In addition to voice & video calls, the SDK supports realtime screen-sharing and in-app remote control, referred to as _In-app CoBrowsing_. This means that you can control your mobile app from any supported browser. This allows you to give visual guidance and helps you resolve difficult issues more quickly.
-
-Currently we support inbound calls only (that is, an agent calls a consumer).
+the CoApp product is deprecated and will be discontinued from February 28th, 2020 on.
+</div>

--- a/pages/documents/MessagingChannels/MobileAppMessagingSDKforiOS/VoiceandVideoforiOSSDK/Introduction.md
+++ b/pages/documents/MessagingChannels/MobileAppMessagingSDKforiOS/VoiceandVideoforiOSSDK/Introduction.md
@@ -17,3 +17,13 @@ indicator: messaging
 
 the CoApp product is deprecated and will be discontinued from February 28th, 2020 on.
 </div>
+
+LivePerson's **Voice & Video SDK** allows you to communicate with your customers in realtime through your brand's app. The SDK enriches your app with realtime voice & video calling capabilities, built atop of our highly scalable **Messaging SDK** solution.
+
+![Introduction](img/iphone_001.png){:style="max-height:420px;"}
+
+Your agents engage from a web browser using our LiveEngage platform, while your consumers will be using your brand's own app, obtained fom the AppStore.
+
+In addition to voice & video calls, the SDK supports realtime screen-sharing and in-app remote control, referred to as _In-app CoBrowsing_. This means that you can control your mobile app from any supported browser. This allows you to give visual guidance and helps you resolve difficult issues more quickly.
+
+Currently we support inbound calls only (that is, an agent calls a consumer).

--- a/pages/documents/MessagingChannels/MobileAppMessagingSDKforiOS/VoiceandVideoforiOSSDK/LiveEngageConfiguration.md
+++ b/pages/documents/MessagingChannels/MobileAppMessagingSDKforiOS/VoiceandVideoforiOSSDK/LiveEngageConfiguration.md
@@ -17,6 +17,11 @@ subfoldername: Voice and Video for iOS SDK (BETA)
 permalink: mobile-app-messaging-sdk-for-ios-voice-and-video-for-ios-sdk-beta-liveengage-configuration.html
 indicator: messaging
 ---
+<div class="important">
+<h2>Deprecation Notice</h2>
+
+the CoApp product is deprecated and will be discontinued from February 28th, 2020 on.
+</div>
 
 ### Agent Workspace Requirements
 

--- a/pages/documents/MessagingChannels/MobileAppMessagingSDKforiOS/VoiceandVideoforiOSSDK/Sample-Apps.md
+++ b/pages/documents/MessagingChannels/MobileAppMessagingSDKforiOS/VoiceandVideoforiOSSDK/Sample-Apps.md
@@ -11,6 +11,12 @@ permalink: mobile-app-messaging-sdk-for-ios-voice-and-video-for-ios-sdk-beta-sam
 indicator: messaging
 ---
 
+<div class="important">
+<h2>Deprecation Notice</h2>
+
+the CoApp product is deprecated and will be discontinued from February 28th, 2020 on.
+</div>
+
 Bundled with our SDK is a sample application written in `Swift`. It showcases a minimal setup of the __Voice & Video SDK__ bundled together with our __Messaging SDK__.
 
 In order to minimize setup effort, the sample app uses [_CocoaPods_](https://cocoapods.org/about).

--- a/pages/documents/MessagingChannels/MobileAppMessagingSDKforiOS/VoiceandVideoforiOSSDK/appendix.md
+++ b/pages/documents/MessagingChannels/MobileAppMessagingSDKforiOS/VoiceandVideoforiOSSDK/appendix.md
@@ -11,6 +11,12 @@ permalink: mobile-app-messaging-sdk-for-ios-voice-and-video-for-ios-sdk-beta-app
 indicator: messaging
 ---
 
+<div class="important">
+<h2>Deprecation Notice</h2>
+
+the CoApp product is deprecated and will be discontinued from February 28th, 2020 on.
+</div>
+
 ### Third-Party Licences
 
 For a list of third-party licenses please refer to the file **LICENSES.md** located inside the _LPCoAppSDK.framework_


### PR DESCRIPTION
CoApp is deprecated, and we need to add a deprecation notice to the developer docs.

Please also remove the following pages:

- Getting Started
- Customizing
- LiveEngage Configuration
- Sample App
- Appendix

Regarding to the Readme, the maintainer has to remove the pages from the sidebar.