### PR TITLE
Update retrieve-chat-events.md

### DIFF
--- a/pages/Documents/ClientSideConfiguration/ServerChatAPI/Methods/retrieve-chat-events.md
+++ b/pages/Documents/ClientSideConfiguration/ServerChatAPI/Methods/retrieve-chat-events.md
@@ -40,6 +40,7 @@ This method retrieves the chat events. The possible event types include: state, 
 | Name  | Description | Type/Value |
 | :--- | :--- | :--- |
 | from | The ID of the first event that is shown in the response. | numeric |
+| appkey | 721c180b09eb463d9f3191c41762bb68 | string |
 
 ### Response
 


### PR DESCRIPTION
NOTE: My change is only a proposal. Please verify using the appKey is correct and also verify the documentation change.

This page, https://developers.liveperson.com/server-chat-api-methods-retrieve-chat-events.html, indicates that the LivePerson app key is provided using the Authorization header with a value of "LivePerson appKey=721c180b09eb463d9f3191c41762bb68".
The sample Postman collection from https://developers.liveperson.com/server-chat-api-overview.html includes the "d.Chat Events" query, which places the app key as the appKey parameter for the URL.
When testing the difference, attempting to use the Authorization header works for QuickenLoans test account, 18213678, but fails for my development account, 60894318, and the QuickenLoans production account, 88814880. It displays the following error:
  lp_problem=consumer_key_rejected&lp_problem_advice=the appKey is permanently unacceptable to the Service Provider
Using the appKey url parameter does work for my development account, 60894318, and the QuickenLoans production account, 88814880.
I propose that either the page be updated to indicate that the app key should be provided as the appKey parameter or the sample Postman collection should be updated.