### PR TITLE
Code sample: debug line correction

### DIFF
--- a/pages/Documents/ConversationalAI/ConversationBuilder/ScriptingFunctions/manage-the-context-session-store.md
+++ b/pages/Documents/ConversationalAI/ConversationBuilder/ScriptingFunctions/manage-the-context-session-store.md
@@ -136,7 +136,7 @@ The following methods get a variable from the Context Session Store at three, di
 
 ```javascript
 var value = botContext.getGlobalContextData("airlineTicketingBot", "intentThreshold");
-botContext.printDebugMessage("get context data for conversation scope: " + value);
+botContext.printDebugMessage("get context data for global scope: " + value);
 
 var value = botContext.getContextDataForUser("airlineTicketingBot", "intentThreshold");
 botContext.printDebugMessage("get context data for user scope: " + value);


### PR DESCRIPTION
In the code sample for get**Global**ContextData, the debug text should read "get context data for **global** scope" rather than "get context data for **conversation** scope"