### PR TITLE
Content-Type is wrong

### DIFF
--- a/pages/Documents/Security&Authentication/ConsumerAuthentication/detailed-api.md
+++ b/pages/Documents/Security&Authentication/ConsumerAuthentication/detailed-api.md
@@ -114,7 +114,7 @@ HTTP/1.1
 Host: server.example.com
 Path: /token  
 Method: POST
-Content-Type: application/json  
+Content-Type: application/x-www-form-urlencoded  
 Authorization: Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW
 Body:    
 {


### PR DESCRIPTION
Confirmed with Liveperson R&D
Liveperson is working with a standard library that does everything Oauth2/openid
It only requests in application/x-www-form-urlencoded per the RFC. There is no option for JSON in the RFC.