### PR TITLE
:memo: add hint to use fresh bot agents instead CB ones

### DIFF
--- a/pages/Documents/ConversationalAI/Third-PartyBots/getting-started.md
+++ b/pages/Documents/ConversationalAI/Third-PartyBots/getting-started.md
@@ -40,7 +40,7 @@ Each connector provides the ability to:
 Some connectors may provide more or less functionality depending on the specifics of the provider.
 
 {: .important}
-Please be advised that you should create fresh bot agents for your bots. Using the same bot agents for ConversationBuilder and ThirdPartyBots will break both bot instances. This happens because only one active user session at time is possible within the ConversationalCloud ecosystem, so bots using the same bot agent will kick each other out.
+Please be advised that you should create fresh bot agents for your bots. Using the same bot agents for ConversationBuilder and ThirdPartyBots will break both bot instances. Conversational Cloud only allows one active user session per agent. Thus, bots created in Conversation Builder and Third-Party Bots with the same bot agent will eventually kick each other out.
 
 {: .important}
 Please be advised that we recommend to have one bot for 100 open and active conversations, if you want your bot to handle more load, please add more bots.

--- a/pages/Documents/ConversationalAI/Third-PartyBots/getting-started.md
+++ b/pages/Documents/ConversationalAI/Third-PartyBots/getting-started.md
@@ -40,6 +40,9 @@ Each connector provides the ability to:
 Some connectors may provide more or less functionality depending on the specifics of the provider.
 
 {: .important}
+Please be advised that you should create fresh bot agents for your bots. Using the same bot agents for ConversationBuilder and ThirdPartyBots will break both bot instances. This happens because only one active user session at time is possible within the ConversationalCloud ecosystem, so bots using the same bot agent will kick each other out.
+
+{: .important}
 Please be advised that we recommend to have one bot for 100 open and active conversations, if you want your bot to handle more load, please add more bots.
 
 {: .important}


### PR DESCRIPTION
add hint to create fresh bot agents fro ThirdPartyBots, since otherwise CB and TPB will kick each other out.