### PR TITLE
adding Ruby version warning, adding lock files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ _algolia_api_key
 .vscode
 vendor
 node_modules/
+package-lock.json
+Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ The max width for an image in this repo is 800px.
 
 ### Building the Site Locally
 
+**IMPORTANT:** This repository requires Ruby 2.7.x. Attempts to run the local server on 3.x.x will generate confusing errors.
+
 If you have not already done so, make sure your computer has Ruby installed. Here's a helpful guide on how best do that on [Mac](http://railsapps.github.io/installrubyonrails-mac.html) (you can stop once Ruby is installed, you don't need Rails) and on [any other system](https://www.ruby-lang.org/en/documentation/installation/).
 
 Once you have installed Ruby, clone this repository to your machine. Once done, navigate to it using Terminal or your preferred command line interface. Follow the steps below to run the site from your machine. **If you're on Windows, don't forget to run your CLI as an admin**.


### PR DESCRIPTION
Added a warning to the readme to prevent new people from going down a needless rabbit hole if they install "ruby latest." Apparently Jekyll and Ruby 3.x.x do not get along and you need to stick with 2.7.x.

Also added the lockfiles to the .gitignore. 