### PR TITLE
fixing phrasing in meta description

### DIFF
--- a/_includes/registerHead.html
+++ b/_includes/registerHead.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" href="{{ "css/register.css" }}">
 <link rel="stylesheet" type="text/css"
     href="https://cdn.rawgit.com/rikmms/progress-bar-4-axios/0a3acf92/dist/nprogress.css" />
-<meta name="description" content="LivePerson for Developers. Build on LiveEngage with our powerful digital toolbox">
+<meta name="description" content="LivePerson for Developers. Build on the LivePerson Conversational Cloud with our powerful digital toolbox">
 <meta name="keywords"
     content="APIs, SDKs, Mobile development, LiveEngage, Agent workspace, Tag, JSON examples, Click to message, Click to chat, Chat window, Skills, Agent Groups, iOS, Android, Mobile devices, Integrations, Live chat, Agent widget, Reporting, Analytics">
 <meta name="author" content="LivePerson Inc.">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,7 @@
   {% include head.html %}
   <link rel="stylesheet" href="{{ "css/search.css" }}">
   <link rel="stylesheet" type="text/css" href="css/inner-page.css">
-  <meta name="description" content="LivePerson for Developers. Build on LiveEngage with our powerful digital toolbox">
+  <meta name="description" content="LivePerson for Developers. Build on the LivePerson Conversational Cloud with our powerful digital toolbox">
   <meta name="keywords"
     content="APIs, SDKs, Mobile development, LiveEngage, Agent workspace, Tag, JSON examples, Click to message, Click to chat, Chat window, Skills, Agent Groups, iOS, Android, Mobile devices, Integrations, Live chat, Agent widget, Reporting, Analytics">
   <meta name="author" content="LivePerson Inc.">

--- a/_layouts/documents.html
+++ b/_layouts/documents.html
@@ -4,7 +4,7 @@
     {% include head.html %}
     <link rel="stylesheet" href="css/categorylanding.css">
     <link rel="stylesheet" href="css/documentsnav.css">
-    <meta name="description" content="LivePerson for Developers. Build on LiveEngage with our powerful digital toolbox">
+    <meta name="description" content="LivePerson for Developers. Build on the LivePerson Conversational Cloud with our powerful digital toolbox">
     <meta name="keywords" content="APIs, SDKs, Mobile development, LiveEngage, Agent workspace, Tag, JSON examples, Click to message, Click to chat, Chat window, Skills, Agent Groups, iOS, Android, Mobile devices, Integrations, Live chat, Agent widget, Reporting, Analytics">
     <meta name="author" content="LivePerson Inc.">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" />

--- a/_layouts/hidden-layout.html
+++ b/_layouts/hidden-layout.html
@@ -4,7 +4,7 @@
   {% include head.html %}
   <link rel="stylesheet" href="{{ "css/search.css" }}">
   <link rel="stylesheet" type="text/css" href="css/inner-page.css">
-  <meta name="description" content="LivePerson for Developers. Build on LiveEngage with our powerful digital toolbox">
+  <meta name="description" content="LivePerson for Developers. Build on the LivePerson Conversational Cloud with our powerful digital toolbox">
   <meta name="keywords"
     content="APIs, SDKs, Mobile development, LiveEngage, Agent workspace, Tag, JSON examples, Click to message, Click to chat, Chat window, Skills, Agent Groups, iOS, Android, Mobile devices, Integrations, Live chat, Agent widget, Reporting, Analytics">
   <meta name="author" content="LivePerson Inc.">

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -3,7 +3,7 @@
     {% include head.html %}
     <link rel="stylesheet" href="{{ "css/search.css" }}">
      <link rel="stylesheet" type="text/css" href="css/inner-page.css">
-     <meta name="description" content="LivePerson for Developers. Build on LiveEngage with our powerful digital toolbox">
+     <meta name="description" content="LivePerson for Developers. Build on the LivePerson Conversational Cloud with our powerful digital toolbox">
      <meta name="keywords" content="APIs, SDKs, Mobile development, LiveEngage, Agent workspace, Tag, JSON examples, Click to message, Click to chat, Chat window, Skills, Agent Groups, iOS, Android, Mobile devices, Integrations, Live chat, Agent widget, Reporting, Analytics">
      <meta name="author" content="LivePerson Inc.">
      <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" />

--- a/_layouts/pagenotfound.html
+++ b/_layouts/pagenotfound.html
@@ -3,7 +3,7 @@
     {% include head.html %}
 
      <link rel="stylesheet" type="text/css" href="css/notfound.css">
-     <meta name="description" content="LivePerson for Developers. Build on LiveEngage with our powerful digital toolbox">
+     <meta name="description" content="LivePerson for Developers. Build on the LivePerson Conversational Cloud with our powerful digital toolbox">
      <meta name="keywords" content="APIs, SDKs, Mobile development, LiveEngage, Agent workspace, Tag, JSON examples, Click to message, Click to chat, Chat window, Skills, Agent Groups, iOS, Android, Mobile devices, Integrations, Live chat, Agent widget, Reporting, Analytics">
      <meta name="author" content="LivePerson Inc.">
 

--- a/_layouts/solutions.html
+++ b/_layouts/solutions.html
@@ -4,7 +4,7 @@
     {% include head.html %}
     <link rel="stylesheet" href="css/categorylanding.css">
     <link rel="stylesheet" href="css/documentsnav.css">
-    <meta name="description" content="LivePerson for Developers. Build on LiveEngage with our powerful digital toolbox">
+    <meta name="description" content="LivePerson for Developers. Build on the LivePerson Conversational Cloud with our powerful digital toolbox">
     <meta name="keywords" content="APIs, SDKs, Mobile development, LiveEngage, Agent workspace, Tag, JSON examples, Click to message, Click to chat, Chat window, Skills, Agent Groups, iOS, Android, Mobile devices, Integrations, Live chat, Agent widget, Reporting, Analytics">
     <meta name="author" content="LivePerson Inc.">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" />


### PR DESCRIPTION
Changes "LiveEngage" to "the LivePerson Conversational Cloud" in the meta description in 7 base template docs.