### PR TITLE
docs: rename to shift focus on API keys generation

### DIFF
--- a/_data/documentsupdated.yaml
+++ b/_data/documentsupdated.yaml
@@ -10,7 +10,7 @@
   image: api-guidelines
   documents:
     - documentname: Accessing LivePerson APIs
-    - documentname: Create OAuth 1.0 API keys
+    - documentname: Create API keys
     - documentname: OAuth 2.0 Client Credentials
     - documentname: Domain API
     - documentname: Data APIs

--- a/pages/Documents/APIGuidelines/create-api-keys.md
+++ b/pages/Documents/APIGuidelines/create-api-keys.md
@@ -1,8 +1,8 @@
 ---
-pagename: Create OAuth 1.0 API keys
+pagename: Create API keys
 sitesection: Documents
 categoryname: "API Guidelines"
-permalink: create-oauth-1-0-api-keys.html
+permalink: create-api-keys.html
 indicator: both
 redirect_from:
   - essential-resources-create-api-keys.html
@@ -11,6 +11,7 @@ redirect_from:
   - guides-gettingstarted.html
   - retrieve-api-keys-create-a-new-api-key.html
   - create-a-new-api-key.html
+  - create-oauth-1-0-api-keys.html
 ---
 
 ### Create an OAuth 1.0 API key


### PR DESCRIPTION
(This affects https://developers.liveperson.com/create-oauth-1-0-api-keys.html)

Signed-off-by: Jens Oliver Meiert <jens@meiert.com>